### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .bsp
 .idea
-target
+target/


### PR DESCRIPTION
add / suffix to "target" word on purpose to match only directory. on the other hand, No add prefix / to it on purpose to match "project/target/" directory too.